### PR TITLE
device-xioami-pipa: install pipewire config to correct location

### DIFF
--- a/device-xiaomi-pipa/PKGBUILD
+++ b/device-xiaomi-pipa/PKGBUILD
@@ -49,8 +49,8 @@ package() {
 	install -Dm644 "${srcdir}/hifi.conf" "${pkgdir}/usr/share/alsa/ucm2/Qualcomm/sm8250/HiFi_pipa.conf"
 
 	# /usr/share/wireplumber.conf.d/51-pipa.conf
-	mkdir -p "${pkgdir}/usr/share/wireplumber.conf.d/51-pipa.conf"
-	install -Dm644 "${srcdir}/wireplumber.conf" "${pkgdir}/usr/share/wireplumber.conf.d/51-pipa.conf"	
+	mkdir -p "${pkgdir}/usr/share/wireplumber/wireplumber.conf.d"
+	install -Dm644 "${srcdir}/wireplumber.conf" "${pkgdir}/usr/share/wireplumber/wireplumber.conf.d/51-pipa.conf"	
 }
 
 


### PR DESCRIPTION
The pipewire config is not being loaded due to a mistake in the PKGBUILD => low volume. This should fix it.